### PR TITLE
Don't define `_CRT_SECURE_NO_WARNINGS` if it's already defined.

### DIFF
--- a/src/ccd/compiler.h
+++ b/src/ccd/compiler.h
@@ -55,10 +55,10 @@
 # pragma warning(disable:981)
 #endif /* __ICC */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 // disable unsafe function warning
 # define _CRT_SECURE_NO_WARNINGS
-#endif /* _MSC_VER */
+#endif /* defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS) */
 
 #endif /* __CCD_COMPILER_H__ */
 


### PR DESCRIPTION
This is applicable e.g. when `-D_CRT_SECURE_NO_WARNINGS` is passed as a compiler flag.