### PR TITLE
Fix pkgconfig file with absolute CMAKE_INSTALL_*DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,12 @@ set(CCD_VERSION ${CCD_VERSION_MAJOR}.${CCD_VERSION_MINOR})
 
 set(CCD_SOVERSION 2)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Include GNUInstallDirs to get canonical paths
 include(GNUInstallDirs)
 include(CTest)
+include(JoinPaths)
 
 option(BUILD_DOCUMENTATION "Build the documentation" OFF)
 
@@ -68,6 +71,8 @@ install(FILES
 
 set(CCD_PKGCONFIG_DESCRIPTION
   "Library for collision detection between convex shapes")
+join_paths(CCD_PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(CCD_PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(ccd.pc.in ccd.pc @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/ccd.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/ccd.pc.in
+++ b/ccd.pc.in
@@ -2,8 +2,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CCD_PKGCONFIG_LIBDIR@
+includedir=@CCD_PKGCONFIG_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @CCD_PKGCONFIG_DESCRIPTION@

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
The CMAKE_INSTALL_*DIR variables are allowed to be absolute paths, but the pkgconfig file template assumes they are relative. This is a common problem, and the fix is described here:
https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files